### PR TITLE
Enable fmiLogging from resolvers and pass to ecos logger

### DIFF
--- a/src/ecos/fmi/fmi_model.hpp
+++ b/src/ecos/fmi/fmi_model.hpp
@@ -17,7 +17,7 @@ class fmi_model : public model
 {
 
 public:
-    explicit fmi_model(const std::filesystem::path& fmuPath, bool fmiLogging = false)
+    explicit fmi_model(const std::filesystem::path& fmuPath, bool fmiLogging = true)
         : fmu_(fmilibcpp::loadFmu(fmuPath, fmiLogging))
     { }
 

--- a/src/fmilibcpp/fmi2/fmi2_slave.cpp
+++ b/src/fmilibcpp/fmi2/fmi2_slave.cpp
@@ -4,7 +4,9 @@
 #include <fmi4c.h>
 
 #include <cstdarg>
+#include <iostream>
 #include <memory>
+#include <sstream>
 
 namespace
 {
@@ -26,10 +28,14 @@ void fmilogger(fmi2Component, fmi2String instanceName, fmi2Status status, fmi2St
 {
     va_list args;
     va_start(args, message);
-    char msgstr[1024];
-    sprintf(msgstr, "[%s] %s: %s\n", fmi2StatusToString(status), instanceName, message);
-    printf(msgstr, args);
+    char formatted[1024];
+    vsnprintf(formatted, sizeof(formatted), message, args);
     va_end(args);
+
+    std::ostringstream ss;
+    ss << "[" << instanceName << "] " << fmi2StatusToString(status) << " " << formatted << "\n";
+
+    ecos::log::debug(ss.str());
 }
 
 void noopfmilogger(fmi2Component, fmi2String, fmi2Status, fmi2String, fmi2String, ...)

--- a/src/fmilibcpp/fmi3/fmi3_slave.cpp
+++ b/src/fmilibcpp/fmi3/fmi3_slave.cpp
@@ -9,12 +9,29 @@
 namespace
 {
 
-void loggerFmi3(fmi3InstanceEnvironment /*instanceEnvironment*/,
-    fmi3Status /*status*/,
-    fmi3String category,
+const char* fmi3StatusToString(fmi3Status status) {
+    switch (status) {
+        case fmi3OK:      return "OK";
+        case fmi3Warning: return "Warning";
+        case fmi3Discard: return "Discard";
+        case fmi3Error:   return "Error";
+        case fmi3Fatal:   return "Fatal";
+        default:          return "Unknown";
+    }
+}
+
+void loggerFmi3(fmi3InstanceEnvironment c,
+    fmi3Status status,
+    fmi3String /*category*/,
     fmi3String message)
 {
-    printf("%s: %s\n", category, message);
+
+    const auto slave = static_cast<fmilibcpp::fmi3_slave*>(c);
+
+    std::ostringstream ss;
+    ss << "[" << slave->instanceName << "] " << fmi3StatusToString(status) << " " << message << "\n";
+
+    ecos::log::debug(ss.str());
 }
 
 } // namespace
@@ -40,7 +57,7 @@ fmi3_slave::fmi3_slave(
         fmi3False,
         nullptr,
         0,
-        nullptr,
+        this,
         loggerFmi3,
         nullptr);
 


### PR DESCRIPTION
Enable fmiLogging when using resolvers and replace `printf` with `ecos::debug`